### PR TITLE
Update screenshot URL

### DIFF
--- a/src/soundkonverter.appdata.xml
+++ b/src/soundkonverter.appdata.xml
@@ -47,7 +47,7 @@
 
     <screenshots>
         <screenshot type="default">
-            <image width="694" height="390">https://screenshots.debian.net/image/14704_large.png</image>
+            <image width="694" height="390">https://screenshots.debian.net/shrine/screenshot/14704/simage/large-0f89a34af77e73454bc273a88a238bf9.png</image>
         </screenshot>
     </screenshots>
 </component>


### PR DESCRIPTION
Debian changed its screenshot URLs, so it needs to be updated. However, it would be the best if a screenshot would be added to the Github repository, and referenced from there.